### PR TITLE
requires-inputLoad-upstream

### DIFF
--- a/d6tflow/__init__.py
+++ b/d6tflow/__init__.py
@@ -2,7 +2,7 @@ import warnings
 import luigi
 from luigi.task import flatten
 import luigi.tools.deps
-from luigi.util import inherits, requires
+from luigi.util import inherits as luigi_inherits, requires as luigi_requires
 from luigi.parameter import (
     Parameter,
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter, DateSecondParameter,
@@ -236,3 +236,58 @@ def clone_parent(cls):
     setattr(cls, 'requires', requires)
     return cls
 
+#Like luigi.utils.inherits but for handling dictionaries
+class dict_inherits:
+    def __init__(self, *tasks_to_inherit):
+        super(dict_inherits, self).__init__()
+        if not tasks_to_inherit:
+            raise TypeError("tasks_to_inherit cannot be empty")
+        #We know the first arg is a dict.
+        self.tasks_to_inherit = tasks_to_inherit[0]
+        
+    def __call__(self, task_that_inherits):
+        for task_to_inherit in self.tasks_to_inherit:                   
+            for param_name, param_obj in self.tasks_to_inherit[task_to_inherit].get_params():
+                # Check if the parameter exists in the inheriting task                    
+                if not hasattr(task_that_inherits, param_name):
+                    # If not, add it to the inheriting task
+                    setattr(task_that_inherits, param_name, param_obj)
+
+        #adding dictionary functionality
+        def clone_parents_dict(_self, **kwargs):
+            return {
+                task_to_inherit: _self.clone(cls=self.tasks_to_inherit[task_to_inherit], **kwargs)
+                for task_to_inherit in self.tasks_to_inherit
+            }
+        task_that_inherits.clone_parents_dict = clone_parents_dict
+        return task_that_inherits
+
+
+#Like luigi.utils.requires but for handling dictionaries
+class dict_requires:
+    def __init__(self, *tasks_to_require):
+        super(dict_requires, self).__init__()
+        if not tasks_to_require:
+            raise TypeError("tasks_to_require cannot be empty")
+        
+        self.tasks_to_require = tasks_to_require[0] #Assign the dictionary 
+
+    def __call__(self, task_that_requires):
+        task_that_requires = dict_inherits(self.tasks_to_require)(task_that_requires)
+        def requires(_self):
+            return _self.clone_parents_dict()
+            
+        task_that_requires.requires = requires
+
+        return task_that_requires
+
+def inherits(*tasks_to_inherit):
+    if isinstance(tasks_to_inherit[0], dict):
+        return dict_inherits(*tasks_to_inherit)
+    return luigi_inherits(*tasks_to_inherit)
+
+def requires(*tasks_to_require):
+    #Check the type; if a dictionary call our custom requires decorator
+    if isinstance(tasks_to_require[0], dict):
+        return dict_requires(*tasks_to_require)
+    return luigi_requires(*tasks_to_require)

--- a/d6tflow/utils.py
+++ b/d6tflow/utils.py
@@ -46,3 +46,7 @@ def traverse(t, path=None):
         if not node in path:
             path = traverse(node, path)
     return path
+
+def to_parquet(df, path, **kwargs):
+    opts = {**{'compression': 'gzip', 'engine': 'pyarrow'}, **kwargs}
+    df.to_parquet(path, **opts)

--- a/tests/flow-d6tpipe.py
+++ b/tests/flow-d6tpipe.py
@@ -1,0 +1,133 @@
+
+#********************************************
+# pipe
+#********************************************
+import yaml
+import d6tpipe
+import pytest
+import fuckit
+from main import *
+cfg = yaml.safe_load(open('tests/.creds.yml'))
+
+
+@pytest.fixture
+def cleanup_pipe():
+    d6tpipe.api.ConfigManager(profile=cfg['d6tpipe_profile']).init({'filerepo': 'tests/d6tpipe-files1/'}, reset=True)
+    api1 = d6tpipe.APIClient(profile=cfg['d6tpipe_profile'])
+    api1.login(cfg['d6tpipe_username'],cfg['d6tpipe_password'])
+    # d6tpipe.api.create_pipe_with_remote(api, {'name': cfg['d6tpipe_pipe1'], 'protocol': 'd6tfree'})
+    # settings = {"user":cfg['d6tpipe_username2'],"role":"read"}
+    # d6tpipe.create_or_update_permissions(api1, cfg['d6tpipe_pipe1'], settings)
+
+    pipe1 = d6tpipe.Pipe(api1, cfg['d6tpipe_pipe1'])
+    pipe1.delete_files_local(confirm=False,delete_all=True)
+
+    d6tpipe.api.ConfigManager(profile=cfg['d6tpipe_profile2']).init({'filerepo': 'tests/d6tpipe-files2/'}, reset=True)
+    api2 = d6tpipe.APIClient(profile=cfg['d6tpipe_profile2'])
+    api2.login(cfg['d6tpipe_username2'],cfg['d6tpipe_password2'])
+    # d6tpipe.api.create_pipe_with_remote(api2, {'name': cfg['d6tpipe_pipe2'], 'protocol': 'd6tfree'})
+    pipe12 = d6tpipe.Pipe(api2, cfg['d6tpipe_pipe1'])
+    pipe2 = d6tpipe.Pipe(api2, cfg['d6tpipe_pipe2'])
+    pipe12.delete_files_local(confirm=False,delete_all=True)
+    pipe2.delete_files_local(confirm=False,delete_all=True)
+
+    yield api1, api2
+
+    @fuckit
+    def delhelper():
+        pipe1.delete_files_local(confirm=False, delete_all=True)
+        pipe12.delete_files_local(confirm=False, delete_all=True)
+        pipe2.delete_files_local(confirm=False, delete_all=True)
+
+    delhelper()
+
+def test_pipes_base(cleanup_pipe):
+    import d6tflow.pipes
+    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'])
+
+    t1 = Task1()
+    pipe1 = d6tflow.pipes.get_pipe()
+    pipedir = pipe1.dirpath
+    t1filepath = t1.output().path
+    t1file = str(PurePosixPath(t1filepath.relative_to(pipedir)))
+
+    assert d6tflow.run(t1)
+    assert t1.complete()
+    with fuckit:
+        pipe1._pullpush_luigi([t1file], op='remove')
+    assert pipe1.push_preview()==[t1file]
+    assert pipe1.push()==[t1file]
+    assert pipe1.scan_remote(cached=False) == [t1file]
+    # cleanup
+    pipe1.delete_files(confirm=False, all_local=True)
+    assert pipe1.scan_remote(cached=False) == []
+
+def test_pipes_advanced(cleanup_pipe):
+    import d6tflow.pipes
+    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'], local_pipe=True, reset=True)
+    assert 'Local' in d6tflow.pipes.get_pipe().__class__.__name__
+    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'], reset=True)
+
+
+    class Task1(d6tflow.tasks.TaskPqPandas):
+        def run(self):
+            self.save(df)
+
+    t1 = Task1()
+    pipe1 = t1.get_pipe()
+    pipedir = pipe1.dirpath
+    t1filepath = t1.output().path
+    t1file = str(PurePosixPath(t1filepath.relative_to(pipedir)))
+
+    d6tflow.preview(t1)
+    assert d6tflow.run(t1)
+    assert t1.complete()
+
+    with fuckit:
+        pipe1._pullpush_luigi([t1file], op='remove')
+
+    assert pipe1.scan_remote(cached=False) == []
+    assert t1.pull_preview()==[]
+    assert t1.push_preview()==[t1file]
+    assert d6tflow.pipes.all_push_preview(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
+    assert d6tflow.pipes.all_push(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
+
+    class Task1(d6tflow.tasks.TaskPqPandas):
+        external = True
+        pipename = cfg['d6tpipe_pipe1']
+
+    class Task2(d6tflow.tasks.TaskPqPandas):
+        persist = ['df2', 'df4']
+        def requires(self):
+            return Task1()
+        def run(self):
+            df2fun(self)
+
+    import importlib
+    importlib.reload(d6tflow)
+    importlib.reload(d6tflow.pipes)
+    d6tflow.cache.pipes={}
+    d6tflow.pipes.init(cfg['d6tpipe_pipe2'],profile=cfg['d6tpipe_profile2'],reset=True)
+    t1 = Task1()
+    assert t1.get_pipename()==cfg['d6tpipe_pipe1']
+    assert not t1.complete()
+    assert t1.pull_preview()==[str(t1file)]
+    assert d6tflow.pipes.all_pull_preview(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
+    assert t1.pull()==[str(t1file)]
+    assert t1.complete()
+    assert t1.output().load().equals(df)
+
+    t2 = Task2()
+    d6tflow.show([t2])
+    assert d6tflow.run([t2]) # run as list
+
+    pipe2 = t2.get_pipe()
+    pipedir = t2.get_pipe().dirpath
+    # assert False
+    t2files = [str(PurePosixPath(p.path.relative_to(pipedir))) for p in t2.output().values()]
+
+    assert d6tflow.pipes.all_push_preview(t2) == {cfg['d6tpipe_pipe2']:t2files}
+
+    # cleanup
+    pipe1._pullpush_luigi([t1file], op='remove')
+    assert pipe1.scan_remote(cached=False) == []

--- a/tests/main.py
+++ b/tests/main.py
@@ -22,6 +22,7 @@ dfc2['a']=dfc2['a']*2
 dfc4 = df.copy()
 dfc4['a']=dfc4['a']*2*2
 
+
 @pytest.fixture
 def cleanup(scope="module"):
     with fuckit:
@@ -213,6 +214,23 @@ def test_formats(cleanup):
         helper(ddf, TaskPqDask, 'pd')
         t1.invalidate(confirm=False)
 
+def test_requires():
+    class Task1(d6tflow.tasks.TaskCache):
+        def run(self):
+            df = pd.DataFrame({'a': range(3)})
+            self.save(df)  # quickly save dataframe
+    class Task2(Task1):
+        pass
+    # define another task that depends on data from task1 and task2
+    @d6tflow.requires({'a': Task1, 'b': Task2})
+    class Task3(d6tflow.tasks.TaskCache):
+        def run(self):
+            df1 = self.input()['a'].load()  # quickly load input data
+            df2 = self.input()['b'].load()  # quickly load input data
+            
+            assert(df1.equals(pd.DataFrame({'a': range(3)})))
+    task3 = Task3()
+    d6tflow.run(task3)
 
 
 def test_params(cleanup):
@@ -341,135 +359,4 @@ def test_dynamic():
     assert TaskCollector().outputLoad()[1][0].equals(Task2().outputLoad()[0])
     TaskCollector().invalidate(confirm=False)
     assert not (Task1().complete() and Task2().complete() and TaskCollector().complete())
-
-#********************************************
-# pipe
-#********************************************
-import yaml
-import d6tpipe
-
-cfg = yaml.safe_load(open('tests/.creds.yml'))
-
-
-@pytest.fixture
-def cleanup_pipe():
-    d6tpipe.api.ConfigManager(profile=cfg['d6tpipe_profile']).init({'filerepo': 'tests/d6tpipe-files1/'}, reset=True)
-    api1 = d6tpipe.APIClient(profile=cfg['d6tpipe_profile'])
-    api1.login(cfg['d6tpipe_username'],cfg['d6tpipe_password'])
-    # d6tpipe.api.create_pipe_with_remote(api, {'name': cfg['d6tpipe_pipe1'], 'protocol': 'd6tfree'})
-    # settings = {"user":cfg['d6tpipe_username2'],"role":"read"}
-    # d6tpipe.create_or_update_permissions(api1, cfg['d6tpipe_pipe1'], settings)
-
-    pipe1 = d6tpipe.Pipe(api1, cfg['d6tpipe_pipe1'])
-    pipe1.delete_files_local(confirm=False,delete_all=True)
-
-    d6tpipe.api.ConfigManager(profile=cfg['d6tpipe_profile2']).init({'filerepo': 'tests/d6tpipe-files2/'}, reset=True)
-    api2 = d6tpipe.APIClient(profile=cfg['d6tpipe_profile2'])
-    api2.login(cfg['d6tpipe_username2'],cfg['d6tpipe_password2'])
-    # d6tpipe.api.create_pipe_with_remote(api2, {'name': cfg['d6tpipe_pipe2'], 'protocol': 'd6tfree'})
-    pipe12 = d6tpipe.Pipe(api2, cfg['d6tpipe_pipe1'])
-    pipe2 = d6tpipe.Pipe(api2, cfg['d6tpipe_pipe2'])
-    pipe12.delete_files_local(confirm=False,delete_all=True)
-    pipe2.delete_files_local(confirm=False,delete_all=True)
-
-    yield api1, api2
-
-    @fuckit
-    def delhelper():
-        pipe1.delete_files_local(confirm=False, delete_all=True)
-        pipe12.delete_files_local(confirm=False, delete_all=True)
-        pipe2.delete_files_local(confirm=False, delete_all=True)
-
-    delhelper()
-
-def test_pipes_base(cleanup_pipe):
-    import d6tflow.pipes
-    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'])
-
-    t1 = Task1()
-    pipe1 = d6tflow.pipes.get_pipe()
-    pipedir = pipe1.dirpath
-    t1filepath = t1.output().path
-    t1file = str(PurePosixPath(t1filepath.relative_to(pipedir)))
-
-    assert d6tflow.run(t1)
-    assert t1.complete()
-    with fuckit:
-        pipe1._pullpush_luigi([t1file], op='remove')
-    assert pipe1.push_preview()==[t1file]
-    assert pipe1.push()==[t1file]
-    assert pipe1.scan_remote(cached=False) == [t1file]
-    # cleanup
-    pipe1.delete_files(confirm=False, all_local=True)
-    assert pipe1.scan_remote(cached=False) == []
-
-def test_pipes_advanced(cleanup_pipe):
-    import d6tflow.pipes
-    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'], local_pipe=True, reset=True)
-    assert 'Local' in d6tflow.pipes.get_pipe().__class__.__name__
-    d6tflow.pipes.init(cfg['d6tpipe_pipe1'],profile=cfg['d6tpipe_profile'], reset=True)
-
-
-    class Task1(d6tflow.tasks.TaskPqPandas):
-        def run(self):
-            self.save(df)
-
-    t1 = Task1()
-    pipe1 = t1.get_pipe()
-    pipedir = pipe1.dirpath
-    t1filepath = t1.output().path
-    t1file = str(PurePosixPath(t1filepath.relative_to(pipedir)))
-
-    d6tflow.preview(t1)
-    assert d6tflow.run(t1)
-    assert t1.complete()
-
-    with fuckit:
-        pipe1._pullpush_luigi([t1file], op='remove')
-
-    assert pipe1.scan_remote(cached=False) == []
-    assert t1.pull_preview()==[]
-    assert t1.push_preview()==[t1file]
-    assert d6tflow.pipes.all_push_preview(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
-    assert d6tflow.pipes.all_push(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
-
-    class Task1(d6tflow.tasks.TaskPqPandas):
-        external = True
-        pipename = cfg['d6tpipe_pipe1']
-
-    class Task2(d6tflow.tasks.TaskPqPandas):
-        persist = ['df2', 'df4']
-        def requires(self):
-            return Task1()
-        def run(self):
-            df2fun(self)
-
-    import importlib
-    importlib.reload(d6tflow)
-    importlib.reload(d6tflow.pipes)
-    d6tflow.cache.pipes={}
-    d6tflow.pipes.init(cfg['d6tpipe_pipe2'],profile=cfg['d6tpipe_profile2'],reset=True)
-    t1 = Task1()
-    assert t1.get_pipename()==cfg['d6tpipe_pipe1']
-    assert not t1.complete()
-    assert t1.pull_preview()==[str(t1file)]
-    assert d6tflow.pipes.all_pull_preview(t1) == {cfg['d6tpipe_pipe1']:[t1file]}
-    assert t1.pull()==[str(t1file)]
-    assert t1.complete()
-    assert t1.output().load().equals(df)
-
-    t2 = Task2()
-    d6tflow.show([t2])
-    assert d6tflow.run([t2]) # run as list
-
-    pipe2 = t2.get_pipe()
-    pipedir = t2.get_pipe().dirpath
-    # assert False
-    t2files = [str(PurePosixPath(p.path.relative_to(pipedir))) for p in t2.output().values()]
-
-    assert d6tflow.pipes.all_push_preview(t2) == {cfg['d6tpipe_pipe2']:t2files}
-
-    # cleanup
-    pipe1._pullpush_luigi([t1file], op='remove')
-    assert pipe1.scan_remote(cached=False) == []
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -146,16 +146,16 @@ def test_tasks(cleanup):
         def requires(self):
             return {1:Task1(), 2:Task1()}
         def run(self):
-            dft1, dft2 = self.inputLoad()
-            assert dft1.equals(dft2)
+            input = self.inputLoad()
+            assert input[1].equals(input[2])
     TaskMultiInput().run()
 
     class TaskMultiInput2(d6tflow.tasks.TaskCache):
         def requires(self):
-            return {'in1':Task2(), 'in1':Task2()}
+            return {'in1':Task2(), 'in2':Task2()}
         def run(self):
-            df2, df4 = self.inputLoad(task='in1')
-            assert df2.equals(dfc2) and df4.equals(dfc4)
+            input = self.inputLoad(task='in1')
+            assert input['df2'].equals(dfc2) and input['df4'].equals(dfc4)
     TaskMultiInput2().run()
 
     # check downstream incomplete
@@ -232,6 +232,73 @@ def test_requires():
     task3 = Task3()
     d6tflow.run(task3)
 
+def test_flow():
+    class Task1(d6tflow.tasks.TaskCache):
+        persist = ['a1','a2']
+        def run(self):
+            df = pd.DataFrame({'a':range(3)})
+            self.save({'a1':df,'a2':df}) 
+    class Task2(d6tflow.tasks.TaskCache):
+        def run(self):
+            df = pd.DataFrame({'a':range(3)})
+            self.save(df) 
+            
+    @d6tflow.requires(Task1,Task2)
+    class Task3(d6tflow.tasks.TaskCache):
+        multiplier = d6tflow.IntParameter()
+        def run(self):
+            df1 = self.input()[0]['a1'].load()
+            df2 = self.input()[1].load()
+            assert df2.equals(df1)
+            df = df1.join(df2, lsuffix='1', rsuffix='2')
+            df['b']=df['a1']*self.multiplier # use task parameter
+            self.save(df)
+
+    params = dict(multiplier=2)
+    dag = d6tflow.flow(params=params)
+
+    dag.run(forced_all_upstream=True,confirm=False)
+    assert dag.outputLoad('Task1')['a1'].equals(dag.outputLoad('Task2'))
+    dfc = dag.outputLoad('Task3')
+    assert (dfc['b']==dfc['a1']*params['multiplier']).all()
+
+    dag.run('Task3',forced_all_upstream=True,confirm=False) # d6tflow.run(Task3())
+    assert dag.outputLoad('Task1')['a1'].equals(dag.outputLoad('Task2'))
+    dfc = dag.outputLoad('Task3')
+    assert (dfc['b']==dfc['a1']*params['multiplier']).all()
+
+    dag.run(['Task3'],forced_all_upstream=True,confirm=False) # d6tflow.run([Task3()])
+    assert dag.outputLoad('Task1')['a1'].equals(dag.outputLoad('Task2'))
+    dfc = dag.outputLoad('Task3')
+    assert (dfc['b']==dfc['a1']*params['multiplier']).all()
+
+def test_multiple_deps_on_input_load():
+    # define 2 tasks that load raw data
+    class Task1(d6tflow.tasks.TaskCache):
+        persist = ['a1','a2']
+        def run(self):
+            df = pd.DataFrame({'a':range(3)})
+            self.save({'a1':df,'a2':df}) # quickly save dataframe
+
+    class Task2(d6tflow.tasks.TaskCache):
+        def run(self):
+            df = pd.DataFrame({'a':range(3)})
+            self.save(df) # quickly save dataframe
+
+    # define another task that depends on data from task1 and task2
+    @d6tflow.requires(Task1,Task2)
+    class Task3(d6tflow.tasks.TaskCache):
+        def run(self):
+            data = self.inputLoad() # ===> implement this
+            df1 = data[0]['a1']
+            assert df1.equals(data[0]['a2'])
+            df2 = data[1]
+            assert df2.equals(df1)
+            df = df1.join(df2, lsuffix='1', rsuffix='2')
+            self.save(df)
+
+    # Execute task including all its dependencies
+    d6tflow.run(Task3(),forced_all_upstream=True,confirm=False)
 
 def test_params(cleanup):
     class TaskParam(d6tflow.tasks.TaskCache):

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,0 +1,32 @@
+import unittest
+import pandas as pd
+import d6tflow
+
+class Task1(d6tflow.tasks.TaskCache):  
+    def run(self):
+        df = pd.DataFrame({'a':range(3)})
+        self.save(df) # quickly save dataframe
+
+class Task2(Task1):
+    pass
+
+# define another task that depends on data from task1 and task2
+@d6tflow.requires({'a':Task1,'b':Task2})
+class Task3(d6tflow.tasks.TaskCache):
+    
+    def run(self):
+        df1 = self.input()['a'].load() # quickly load input data
+        df2 = self.input()['b'].load() # quickly load input data
+
+        self.test.assertTrue(df1.equals(pd.DataFrame({'a':range(3)})))
+
+
+
+
+class TestRequires(unittest.TestCase):
+    def test_requires(self):
+        task3 = Task3()
+        task3.test = self
+        
+        d6tflow.run(task3)
+


### PR DESCRIPTION
## What

This adds custom requires and inherits decorators.
Changes inputLoad to handle multiple upstream dependencies.
Changes forced_all_upstream to take precedence over forced_all in d6tflow.run()
I have also added tests for all these.
## Why

Custom requires and inherits were added for supporting dictionary param. These will only be called if param is a dictionary else the original luigi implementation will be used instead.
inputLoad was changed to handle multiple upstream dependencies. Currently only handles one.
When both parameters d6tflow.run(task_, forced_all=True, forced_all_upstream=True) are used force_all_upstream is changed to take precedence. In this case, only force_all_upstream conditional branch is run. Previously both conditional branches were executed. 