### PR TITLE
Calls to invalidate() are now updated to reset()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 data/
 tests/.creds.yml
 tests/tmp.py
+tests-data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/d6tflow/tasks/__init__.py
+++ b/d6tflow/tasks/__init__.py
@@ -269,7 +269,8 @@ class TaskAggregator(luigi.Task):
                 yield Task2()
 
     """
-
+    def reset(self, confirm=True):
+        return self.invalidate(confirm=confirm)
     def invalidate(self, confirm=True):
         [t.invalidate(confirm) for t in self.run()]
 

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -52,7 +52,7 @@ By default, for a task to be complete, it checks if all dependencies are complet
 
 .. code-block:: python
 
-    TaskGetData().invalidate(confirm=False)
+    TaskGetData().reset(confirm=False)
     d6tflow.settings.check_dependencies=True # default
     d6tflow.preview(TaskTrain()) # TaskGetData is pending so all tasks are pending
     '''
@@ -108,7 +108,7 @@ You have several options to force tasks to reset and rerun. See sections below o
     d6tflow.run([TaskTrain()],force=[TaskGetData()])
 
     # reset single task
-    TaskGetData().invalidate()
+    TaskGetData().reset()
 
     # reset all downstream tasks
     d6tflow.invalidate_downstream(TaskGetData(), TaskTrain())

--- a/tests/main.py
+++ b/tests/main.py
@@ -105,7 +105,7 @@ def test_tasks(cleanup):
 
     t1.run()
     assert t1.complete()
-    assert t1.invalidate(confirm=False)
+    assert t1.reset(confirm=False)
     assert not t1.complete()
 
     assert d6tflow.run([Task2()])
@@ -159,7 +159,7 @@ def test_tasks(cleanup):
     TaskMultiInput2().run()
 
     # check downstream incomplete
-    t1.invalidate(confirm=False)
+    t1.reset(confirm=False)
     assert not t2.complete()
     d6tflow.settings.check_dependencies=False
     assert t2.complete()
@@ -212,7 +212,7 @@ def test_formats(cleanup):
         ddf = dd.read_parquet(t1.output().path)
         from d6tflow.tasks.dask import TaskPqDask
         helper(ddf, TaskPqDask, 'pd')
-        t1.invalidate(confirm=False)
+        t1.reset(confirm=False)
 
 def test_requires():
     class Task1(d6tflow.tasks.TaskCache):
@@ -327,10 +327,10 @@ def test_external(cleanup):
 def test_execute(cleanup):
     # execute
     t1=Task1(); t2=Task2();t3=Task3();
-    [t.invalidate(confirm=False) for t in [t1,t2,t3]]
+    [t.reset(confirm=False) for t in [t1,t2,t3]]
     d6tflow.run(t3)
     assert all(t.complete() for t in [t1,t2,t3])
-    t1.invalidate(confirm=False); t2.invalidate(confirm=False);
+    t1.reset(confirm=False); t2.reset(confirm=False);
     assert not t3.complete() # cascade upstream
     d6tflow.settings.check_dependencies=False
     assert t3.complete() # no cascade upstream
@@ -424,6 +424,6 @@ def test_dynamic():
     assert Task1().complete() and Task2().complete() and TaskCollector().complete()
     assert TaskCollector().outputLoad()[0].equals(Task1().outputLoad())
     assert TaskCollector().outputLoad()[1][0].equals(Task2().outputLoad()[0])
-    TaskCollector().invalidate(confirm=False)
+    TaskCollector().reset(confirm=False)
     assert not (Task1().complete() and Task2().complete() and TaskCollector().complete())
 


### PR DESCRIPTION
## What
Changes all mentions of invalidate() to reset() in docs and examples.