### PR TITLE
Add functional way of defining tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can also clone the repo and run `pip install .`
 
 To install latest DEV `pip install git+git://github.com/d6t/d6tflow.git` or upgrade `pip install git+git://github.com/d6t/d6tflow.git -U --no-deps`
 
-## Example: Introduction
+## Example 1: Introduction
 
 This is a minial example. Be sure to check out the ML workflow example below.
 
@@ -111,14 +111,16 @@ d6tflow.preview(Task3(multiplier=3))
 
 ```
 
-
-## Example: Comparing model performance in ML Workflow
+## Example 2: Comparing model performance in ML Workflow
 
 Below is sample output for a machine learning workflow. The goal is to efficiently compare the performance of two ML models.  
 
 **[See the full example here](http://tiny.cc/d6tflow-start-example)**  
 **[Interactive mybinder jupyter notebook example](http://tiny.cc/d6tflow-start-interactive)**
 
+## Example 3: Turn functions into workflows
+
+Alternatively, chain together functions into a workflow and get the power of d6tflow with only little change in code. **[Jupyter notebook example](https://github.com/d6t/d6tflow/blob/master/docs/example-functional.ipynb)**
 
 ## Documentation
 

--- a/d6tflow/functional.py
+++ b/d6tflow/functional.py
@@ -12,7 +12,6 @@ class Flow:
         self.funcs_to_run = []
         self.params = {}
         self.steps = {}
-        self.persist = ["data"]
         self.object_count = 0
 
         def common_decorator(func):
@@ -55,7 +54,6 @@ class Flow:
         self.steps[step_name] = type(step_name, (task_type,), {})
         self.current_step = step_name
         self.object_count += 1
-        self.persist = ["data"]
         return self.common_decorator
 
     def requires(self, *args, **kwargs):
@@ -103,7 +101,6 @@ class Flow:
             -------
             @flow.persists(['a1', 'a2'])
         """
-        self.persist = to_persist
         self.steps[self.current_step].persist = to_persist
         return self.common_decorator
 

--- a/d6tflow/functional.py
+++ b/d6tflow/functional.py
@@ -2,6 +2,7 @@ import d6tflow.tasks as tasks
 import d6tflow
 from functools import wraps
 
+
 class Flow:
     """
         Functional Flow class that acts as a manager of all flow steps.
@@ -12,6 +13,7 @@ class Flow:
         self.funcs_to_run = []
         self.params = {}
         self.steps = {}
+        self.instatiated_tasks = {}
         self.object_count = 0
 
         def common_decorator(func):
@@ -127,12 +129,14 @@ class Flow:
             funcs_to_run, list) else [funcs_to_run]
 
         params = params if params else {}
-        for func_to_run in funcs_to_run:
-            self.steps[func_to_run.__name__] = self.steps[func_to_run.__name__](
-                **params)
+        instatiated_tasks = {
+            func_to_run.__name__: self.steps[func_to_run.__name__](**params)
+            for func_to_run in funcs_to_run
+        }
+        self.instatiated_tasks.update(instatiated_tasks)
 
         d6tflow.run(
-            [self.steps[func_to_run.__name__] for func_to_run in funcs_to_run],
+            list(self.instatiated_tasks.values()),
             *args,
             **kwargs)
 
@@ -167,4 +171,4 @@ class Flow:
         """
         name = func_to_run.__name__
         assert name in self.steps, "The function either does not qualify as a task or has not been run yet.\n Did you forget to decorate your function with one of the classes in d6tflow.tasks?"
-        return self.steps[name].outputLoad(*args, **kwargs)
+        return self.instatiated_tasks[name].outputLoad(*args, **kwargs)

--- a/d6tflow/functional.py
+++ b/d6tflow/functional.py
@@ -1,0 +1,173 @@
+import d6tflow.tasks as tasks
+import d6tflow
+from functools import wraps
+
+class Flow:
+    """
+        Functional Flow class that acts as a manager of all flow steps.
+        Defines all the decorators that can be used on flow functions.
+    """
+
+    def __init__(self):
+        self.funcs_to_run = []
+        self.params = {}
+        self.steps = {}
+        self.persist = ["data"]
+        self.object_count = 0
+
+        def common_decorator(func):
+            """
+                Common decorator that all decorators use.
+            """
+            # Checking if the function that is decorated is the function that we want to run.
+            # If so then we set the function as the run function for the current task class.
+            # Also we are changing the name of the task class to the function name.
+            if not '__wrapped__' in func.__dict__:
+                self.steps[func.__name__] = self.steps[self.current_step]
+                self.steps[func.__name__].__name__ = func.__name__
+                setattr(self.steps[func.__name__], 'run', func)
+
+            # Thanks to wraps, wrapper has all the metadata of func.
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                func(*args, **kwargs)
+            return wrapper
+        self.common_decorator = common_decorator
+
+    def step(self, task_type: d6tflow.tasks.TaskData):
+        """
+            Flow step decorator.
+            Converts the decorated function into a flow step.
+            Should be defined at the top of the decorator stack.
+
+            Parameters
+            ----------
+            task_type : d6ftflow.tasks.TaskData
+                task_type should be a class which inherits from d6ftflow.tasks.TaskData
+
+            Example
+            -------
+            @flow.step(d6tflow.tasks.TaskCache)
+        """
+        assert task_type.__base__ == tasks.TaskData, "Invalid parameter. Parameter should be type defined in d6tflow.tasks"
+        self.task_type = task_type
+        step_name = str(self.object_count)
+        self.steps[step_name] = type(step_name, (task_type,), {})
+        self.current_step = step_name
+        self.object_count += 1
+        self.persist = ["data"]
+        return self.common_decorator
+
+    def requires(self, *args, **kwargs):
+        """
+            Flow requires decorator.
+            Defines dependencies between flow steps.
+            Internally calls d6tflow.requires which inturn calls luigi.requires.
+
+            Parameters
+            ----------
+            func : dict or function or mutiple functions
+
+            Examples
+            --------
+            @flow.requires({"foo": func1, "bar": func2})
+            @flow.requires(func1, func2)
+            @flow.requires(func1)
+        """
+        if isinstance(args[0], dict):
+            tasks_to_require = {}
+            for key in args[0]:
+                tasks_to_require[key] = self.steps[args[0][key].__name__]
+
+            tasks_to_require = [tasks_to_require]
+        else:
+            tasks_to_require = [
+                self.steps[func.__name__]
+                for func in args
+            ]
+
+        self.steps[self.current_step] = d6tflow.requires(
+            *tasks_to_require, **kwargs)(self.steps[self.current_step])
+
+        return self.common_decorator
+
+    def persists(self, to_persist: list):
+        """
+            Flow persists decorator.
+            Takes in a list of variables that need to be persisted for the flow step.
+            Parameters
+            ----------
+            to_persist : list
+
+            Example
+            -------
+            @flow.persists(['a1', 'a2'])
+        """
+        self.persist = to_persist
+        self.steps[self.current_step].persist = to_persist
+        return self.common_decorator
+
+    def run(self, funcs_to_run, params: dict = None, *args, **kwargs):
+        """
+            Runs flow steps locally. See luigi.build for additional details
+            Parameters
+            ----------
+            funcs_to_run : function or list of functions
+
+            params : dict
+                dictionary of paramaters. Keys are param names and values are the values of params.
+
+            Examples
+            --------
+
+            flow.run(func, params={'multiplier':2})
+
+            flow.run([func1, func2], params={'multiplier':42})
+
+            flow.run(func)
+        """
+        funcs_to_run = funcs_to_run if isinstance(
+            funcs_to_run, list) else [funcs_to_run]
+
+        params = params if params else {}
+        for func_to_run in funcs_to_run:
+            self.steps[func_to_run.__name__] = self.steps[func_to_run.__name__](
+                **params)
+
+        d6tflow.run(
+            [self.steps[func_to_run.__name__] for func_to_run in funcs_to_run],
+            *args,
+            **kwargs)
+
+    def add_params(self, params):
+        """
+            Adds params to flow functions.
+            More like declares the params for further use.
+            Parameters
+            ----------
+            params : dict
+                dictionary of param name and param type
+
+            Example
+            -------
+            flow.add_params({'multiplier': d6tflow.IntParameter(default=0)})
+        """
+        for step in self.steps:
+            for param in params:
+                setattr(self.steps[step], param, params[param])
+
+    def outputLoad(self, func_to_run, *args, **kwargs):
+        """
+            Loads all or several outputs from flow step.
+
+            Args:
+                func_to_run: flow step function
+                keys (list): list of data to load
+                as_dict (bool): cache data in memory
+                cached (bool): cache data in memory
+
+            Returns: list or dict of all task output
+        """
+        name = func_to_run.__name__
+        assert name in self.steps, "The function either does not qualify as a task or has not been run yet.\n Did you forget to decorate your function with one of the classes in d6tflow.tasks?"
+        return self.steps[name].outputLoad(*args, **kwargs)

--- a/docs/example-functional.ipynb
+++ b/docs/example-functional.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import d6tflow\n",
+    "import pandas as pd\n",
+    "\n",
+    "from d6tflow.functional import Flow\n",
+    "flow = Flow()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flow.step(d6tflow.tasks.TaskCache)\n",
+    "def get_data1(task):\n",
+    "    df = pd.DataFrame({'a':range(3)})\n",
+    "    task.save(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flow.step(d6tflow.tasks.TaskCache)\n",
+    "def get_data2(task):\n",
+    "    df = pd.DataFrame({'a':range(3)})\n",
+    "    task.save(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@flow.step(d6tflow.tasks.TaskCache)\n",
+    "@flow.requires({\"input1\":get_data1, \"input2\":get_data2})\n",
+    "def use_data(task):\n",
+    "    data = task.inputLoad()\n",
+    "    df1 = data['input1']\n",
+    "    df2 = data['input2']\n",
+    "    df3 = df1.join(df2, lsuffix='1', rsuffix='2')\n",
+    "    df3['b']=df3['a1']*task.multiplier # use task parameter\n",
+    "    task.save(df3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Execute workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow.add_params({'multiplier': d6tflow.IntParameter(default=0)})\n",
+    "use_params = {'multiplier':3}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'Flow' object has no attribute 'preview'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-33-c45d28abb441>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mflow\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpreview\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0muse_data\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0muse_params\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m: 'Flow' object has no attribute 'preview'"
+     ]
+    }
+   ],
+   "source": [
+    "flow.preview(use_data, params=use_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "===== Luigi Execution Summary =====\n",
+      "\n",
+      "Scheduled 3 tasks of which:\n",
+      "* 3 ran successfully:\n",
+      "    - 1 get_data1(multiplier=3)\n",
+      "    - 1 get_data2(multiplier=3)\n",
+      "    - 1 use_data(multiplier=3)\n",
+      "\n",
+      "This progress looks :) because there were no failed tasks or missing dependencies\n",
+      "\n",
+      "===== Luigi Execution Summary =====\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "flow.run(use_data, params=use_params, forced_all_upstream=True, confirm=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'get_data1'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-30-759efb17095b>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mflow\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0moutputLoad\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mget_data1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mC:\\Anaconda3\\lib\\site-packages\\d6tflow\\functional.py\u001b[0m in \u001b[0;36moutputLoad\u001b[1;34m(self, func_to_run, *args, **kwargs)\u001b[0m\n\u001b[0;32m    172\u001b[0m         \u001b[0mname\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc_to_run\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    173\u001b[0m         \u001b[1;32massert\u001b[0m \u001b[0mname\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msteps\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m\"The function either does not qualify as a task or has not been run yet.\\n Did you forget to decorate your function with one of the classes in d6tflow.tasks?\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 174\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0minstatiated_tasks\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0moutputLoad\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m: 'get_data1'"
+     ]
+    }
+   ],
+   "source": [
+    "flow.outputLoad(get_data1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a1</th>\n",
+       "      <th>a2</th>\n",
+       "      <th>b</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a1  a2  b\n",
+       "0   0   0  0\n",
+       "1   1   1  3\n",
+       "2   2   2  6"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flow.outputLoad(use_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/example-functional.ipynb
+++ b/docs/example-functional.ipynb
@@ -2,9 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome to d6tflow!\n"
+     ]
+    }
+   ],
    "source": [
     "import d6tflow\n",
     "import pandas as pd\n",
@@ -22,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,11 +54,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@flow.step(d6tflow.tasks.TaskCache)\n",
+    "@flow.step(d6tflow.tasks.TaskPqPandas)\n",
     "@flow.requires({\"input1\":get_data1, \"input2\":get_data2})\n",
     "def use_data(task):\n",
     "    data = task.inputLoad()\n",
@@ -70,28 +78,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "flow.add_params({'multiplier': d6tflow.IntParameter(default=0)})\n",
-    "use_params = {'multiplier':3}"
+    "use_params = {'multiplier':4}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'Flow' object has no attribute 'preview'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-33-c45d28abb441>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mflow\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpreview\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0muse_data\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0muse_params\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mAttributeError\u001b[0m: 'Flow' object has no attribute 'preview'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " ===== Luigi Execution Preview ===== \n",
+      "\n",
+      "\n",
+      "└─--[use_data-{'multiplier': '4'} (\u001b[94mPENDING\u001b[0m)]\n",
+      "   |--[get_data1- (\u001b[94mPENDING\u001b[0m)]\n",
+      "   └─--[get_data2- (\u001b[94mPENDING\u001b[0m)]\n",
+      "\n",
+      " ===== Luigi Execution Preview ===== \n",
+      "\n"
      ]
     }
    ],
@@ -101,21 +114,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "no tasks to invalidate\n",
       "\n",
       "===== Luigi Execution Summary =====\n",
       "\n",
       "Scheduled 3 tasks of which:\n",
       "* 3 ran successfully:\n",
-      "    - 1 get_data1(multiplier=3)\n",
-      "    - 1 get_data2(multiplier=3)\n",
-      "    - 1 use_data(multiplier=3)\n",
+      "    - 1 get_data1(multiplier=4)\n",
+      "    - 1 get_data2(multiplier=4)\n",
+      "    - 1 use_data(multiplier=4)\n",
       "\n",
       "This progress looks :) because there were no failed tasks or missing dependencies\n",
       "\n",
@@ -130,29 +144,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "'get_data1'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-30-759efb17095b>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mflow\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0moutputLoad\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mget_data1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32mC:\\Anaconda3\\lib\\site-packages\\d6tflow\\functional.py\u001b[0m in \u001b[0;36moutputLoad\u001b[1;34m(self, func_to_run, *args, **kwargs)\u001b[0m\n\u001b[0;32m    172\u001b[0m         \u001b[0mname\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc_to_run\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    173\u001b[0m         \u001b[1;32massert\u001b[0m \u001b[0mname\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msteps\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m\"The function either does not qualify as a task or has not been run yet.\\n Did you forget to decorate your function with one of the classes in d6tflow.tasks?\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 174\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0minstatiated_tasks\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0moutputLoad\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m: 'get_data1'"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a\n",
+       "0  0\n",
+       "1  1\n",
+       "2  2"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "flow.outputLoad(get_data1)"
+    "flow.outputLoad(get_data1, params=use_params)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -192,13 +246,13 @@
        "      <th>1</th>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>3</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2</td>\n",
        "      <td>2</td>\n",
-       "      <td>6</td>\n",
+       "      <td>8</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -207,25 +261,18 @@
       "text/plain": [
        "   a1  a2  b\n",
        "0   0   0  0\n",
-       "1   1   1  3\n",
-       "2   2   2  6"
+       "1   1   1  4\n",
+       "2   2   2  8"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "flow.outputLoad(use_data)"
+    "flow.outputLoad(use_data, params=use_params)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -244,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/tests/main.py
+++ b/tests/main.py
@@ -343,7 +343,7 @@ def test_functional_Flow():
     flow.run([use_data, get_data0], forced_all_upstream=True, confirm=False, params={'multiplier':42})
     flow.run(use_data, forced_all_upstream=True, confirm=False, params={'multiplier':42})
     dfo = pd.DataFrame({'a':range(4)})
-    assert flow.outputLoad(use_data)[0].equals(dfo)
+    assert flow.outputLoad(use_data, params={'multiplier':42})[0].equals(dfo)
     
 def test_params(cleanup):
     class TaskParam(d6tflow.tasks.TaskCache):


### PR DESCRIPTION
This pull-request adds functional decorators to d6tflow.

```python
from d6tflow.functional import Flow
flow = Flow()
```
The above code creates a flow object

To decorate your functions, attach @flow.step like this
```python
@flow.step(d6tflow.tasks.TaskCache)
def get_data1(task):
    df = pd.DataFrame({'a':range(3)})
    task.save(df)
```

Full example at docs/example-functional.ipynb